### PR TITLE
Customized toString Methods

### DIFF
--- a/Test/geo2_util.cpp
+++ b/Test/geo2_util.cpp
@@ -130,9 +130,9 @@ namespace Geo2Util {
     }
 
     /**
-     * @brief Convert Polygon_2 object to string with all its holes and holes' vertices (the interiors of the holes are transparent and white by defalut)
-     * @param poly_w_h 
-     * @return 
+     * @brief Convert Polygon_with_holes_2 object to string with all its holes and holes' vertices (the interiors of the holes are transparent and white by defalut)
+     * @param poly_w_h Polygon_with_holes_2 object
+     * @return A string object containing the representation of Polygon_with_holes_2 object
      */
     std::string toString(const Polygon_with_holes_2& poly_w_h) {
         std::string holes_str = "";
@@ -148,6 +148,32 @@ namespace Geo2Util {
             + holes_str;
     }
 
+    /**
+     * @brief Convert Line_2 object to string with point(0) and point(1)
+     * @param line Line_2 object
+     * @return A string object containing the representation of Line_2 object
+     */
+    std::string toString(const Line_2& line) {
+        
+        return "LINE " + toString(Geo2Util::DefaultBoundaryColor) + " "
+            + toString(Geo2Util::DefaultBoundaryType) + "\n"
+            + toString(line.point(0)) + " " + "\n"
+            + toString(line.point(1));
+    }
+
+    /**
+     * @brief Convert Ray_2 object to string with source() and point(1)
+     * @param ray Ray_2 object
+     * @return A string object containing the representation of Ray_2 object
+     */
+    std::string toString(const Ray_2& ray) {
+
+        return "RAY " + toString(Geo2Util::DefaultBoundaryColor) + " "
+            + toString(Geo2Util::DefaultBoundaryType) + "\n"
+            + toString(ray.source()) + " " + "\n"
+            + toString(ray.point(1));
+    }
+
     // Customized toString
     //! Underlying points of all objects (except Point_2) have the same color (boundary color and interior color) as its boundary color
     //! Underlying points of all objects have the same boundary type as the objects themselves
@@ -156,8 +182,8 @@ namespace Geo2Util {
         s << std::fixed << std::setprecision(10) << "POINT " << p.x() << " "
             << p.y() << " "
             << toString(boundaryColor) << " "
-            << toString(interiorColor) << " "
-            << toString(btype);
+            << toString(btype) << " "
+            << toString(interiorColor);
 
         return s.str();
     }
@@ -229,6 +255,21 @@ namespace Geo2Util {
             + toString(btype) + " "
             + toString(interiorColor) + "\n"
             + holes_str;
+    }
+
+    std::string toString(const Line_2& line, const Color& boundaryColor, const BoundaryType btype) {
+
+        return "LINE " + toString(boundaryColor) + " "
+            + toString(btype) + "\n"
+            + toString(line.point(0), boundaryColor, btype, boundaryColor) + "\n"
+            + toString(line.point(1), boundaryColor, btype, boundaryColor);
+    }
+
+    std::string toString(const Ray_2& ray, const Color& boundaryColor, const BoundaryType btype) {
+        return "RAY " + toString(boundaryColor) + " "
+            + toString(btype) + "\n"
+            + toString(ray.source(), boundaryColor, btype, boundaryColor) + "\n"
+            + toString(ray.point(1), boundaryColor, btype, boundaryColor);
     }
 
     /**

--- a/Test/geo2_util.cpp
+++ b/Test/geo2_util.cpp
@@ -6,9 +6,16 @@
 #include "geo2_util.h"
 
 namespace Geo2Util {
-    std::string Black() {
-        static std::string black(" 0 0 0 255");
-        return black;
+    /**
+     * @brief Convert color to string in a form of "r, g, b, trans"
+     * @param color Color object (r, b, g, trans)
+     * @return A string object containing the representation of Color
+     */
+    std::string toString(const Color& color) {
+        return std::to_string(color.r) + " "
+                + std::to_string(color.g) + " "
+                + std::to_string(color.b) + " "
+                + std::to_string(color.trans);
     }
 
     /**
@@ -25,6 +32,7 @@ namespace Geo2Util {
         }
     }
 
+    // Default color = Color::OpaqueBlack = Color{0, 0, 0, 255}; default boundary type = BoundaryType::Solid
     /**
      * @brief Convert Point_2 object to string with its x and y coordinate
      * @param p Point_2 object
@@ -33,8 +41,11 @@ namespace Geo2Util {
     std::string toString(const Point_2& p) {
 
         std::ostringstream s;
-        s << std::fixed << std::setprecision(10) << "POINT " << p.x() << " " << p.y() 
-            << Black() + toString(BoundaryType::Solid) + Black();
+        s << std::fixed << std::setprecision(10) << "POINT " << p.x() << " "
+            << p.y() << " "
+            << toString(Geo2Util::DefaultBoundaryColor) << " "
+            << toString(Geo2Util::DefaultBoundaryType) << " "
+            << toString(Geo2Util::DefaultInteriorColor);
 
         return s.str();
     }
@@ -46,7 +57,8 @@ namespace Geo2Util {
      */
     std::string toString(const Segment_2& seg) {
 
-        return "LINE_SEGMENT" + Black() + toString(BoundaryType::Dotted) + "\n"
+        return "LINE_SEGMENT " + toString(Geo2Util::DefaultBoundaryColor) + " "
+                + toString(Geo2Util::DefaultBoundaryType) + "\n"
                 + toString(seg.source()) + "\n"
                 + toString(seg.target());
     }
@@ -61,8 +73,10 @@ namespace Geo2Util {
         double raduis = std::sqrt(circ.squared_radius());
 
         std::ostringstream c;
-        c << std::fixed << std::setprecision(10) << "CIRCLE " << raduis 
-            << Black() << toString(BoundaryType::Dashed) << Black() + "\n"
+        c << std::fixed << std::setprecision(10) << "CIRCLE " << raduis << " "
+            << toString(Geo2Util::DefaultBoundaryColor) << " "
+            << toString(Geo2Util::DefaultBoundaryType) << " "
+            << toString(Geo2Util::DefaultInteriorColor) + "\n"
             << toString(circ.center());
 
         return c.str();
@@ -75,7 +89,9 @@ namespace Geo2Util {
      */
     std::string toString(const Triangle_2& tri) {
 
-        return "TRIANGLE" + Black() + toString(BoundaryType::Dotted) + Black() + "\n"
+        return "TRIANGLE " + toString(Geo2Util::DefaultBoundaryColor) + " "
+                + toString(Geo2Util::DefaultBoundaryType) + " "
+                + toString(Geo2Util::DefaultInteriorColor) + "\n"
                 + toString(tri[0]) + "\n"
                 + toString(tri[1]) + "\n"
                 + toString(tri[2]);
@@ -88,7 +104,9 @@ namespace Geo2Util {
      */
     std::string toString(const Iso_rectangle_2& rect) {
 
-        return "RECTANGLE" + Black() + toString(BoundaryType::Dotted) + Black() + "\n"
+        return "RECTANGLE " + toString(Geo2Util::DefaultBoundaryColor) + " "
+                + toString(Geo2Util::DefaultBoundaryType) + " "
+                + toString(Geo2Util::DefaultInteriorColor) + "\n"
                 + toString(rect.min()) + "\n"
                 + toString(rect.max());
     }

--- a/Test/geo2_util.cpp
+++ b/Test/geo2_util.cpp
@@ -32,7 +32,6 @@ namespace Geo2Util {
         }
     }
 
-    // Default color = Color::OpaqueBlack = Color{0, 0, 0, 255}; default boundary type = BoundaryType::Solid
     /**
      * @brief Convert Point_2 object to string with its x and y coordinate
      * @param p Point_2 object
@@ -111,6 +110,66 @@ namespace Geo2Util {
                 + toString(rect.max());
     }
 
+    // Customized toString
+    //! Underlying points of all objects (except Point_2) have the same color (boundary color and interior color) as its boundary color
+    //! Underlying points of all objects have the same boundary type as the objects themselves
+    std::string toString(const Point_2& p, const Color& boundaryColor, const BoundaryType btype, const Color& interiorColor) {
+        std::ostringstream s;
+        s << std::fixed << std::setprecision(10) << "POINT " << p.x() << " "
+            << p.y() << " "
+            << toString(boundaryColor) << " "
+            << toString(interiorColor) << " "
+            << toString(btype);
+
+        return s.str();
+    }
+
+    std::string toString(const Segment_2& seg, const Color& boundaryColor, const BoundaryType btype) {
+
+        return "LINE_SEGMENT " + toString(boundaryColor) + " "
+            + toString(btype) + "\n"
+            + toString(seg.source(), boundaryColor, btype, boundaryColor) + "\n"
+            + toString(seg.target(), boundaryColor, btype, boundaryColor);
+    }
+
+    std::string toString(const Circle_2& circ, const Color& boundaryColor, const BoundaryType btype, const Color& interiorColor) {
+
+        double raduis = std::sqrt(circ.squared_radius());
+
+        std::ostringstream c;
+        c << std::fixed << std::setprecision(10) << "CIRCLE " << raduis << " "
+            << toString(boundaryColor) << " "
+            << toString(interiorColor) << " "
+            << toString(btype) + "\n"
+            << toString(circ.center(), boundaryColor, btype, boundaryColor);
+
+        return c.str();
+    }
+
+    std::string toString(const Triangle_2& tri, const Color& boundaryColor, const BoundaryType btype, const Color& interiorColor) {
+
+        return "TRIANGLE " + toString(boundaryColor) + " "
+            + toString(btype) + " "
+            + toString(interiorColor) + "\n"
+            + toString(tri[0], boundaryColor, btype, boundaryColor) + "\n"
+            + toString(tri[1], boundaryColor, btype, boundaryColor) + "\n"
+            + toString(tri[2], boundaryColor, btype, boundaryColor);
+    }
+
+    std::string toString(const Iso_rectangle_2& rect, const Color& boundaryColor, const BoundaryType btype, const Color& interiorColor) {
+
+        return "RECTANGLE " + toString(boundaryColor) + " "
+            + toString(btype) + " "
+            + toString(interiorColor) + "\n"
+            + toString(rect.min(), boundaryColor, btype, boundaryColor) + "\n"
+            + toString(rect.max(), boundaryColor, btype, boundaryColor);
+    }
+
+    /**
+     * @brief Export a collect of 2D geometry objects to a file
+     * @param filename Export target file
+     * @param geo2_Objects String representations of a collection of 2D geometry objects
+     */
     void printToFile(const std::string& filename, const std::vector<std::string>& geo2_Objects) {
 
         std::ofstream output(filename);

--- a/Test/geo2_util.cpp
+++ b/Test/geo2_util.cpp
@@ -13,9 +13,9 @@ namespace Geo2Util {
      */
     std::string toString(const Color& color) {
         return std::to_string(color.r) + " "
-                + std::to_string(color.g) + " "
-                + std::to_string(color.b) + " "
-                + std::to_string(color.trans);
+            + std::to_string(color.g) + " "
+            + std::to_string(color.b) + " "
+            + std::to_string(color.trans);
     }
 
     /**
@@ -57,9 +57,9 @@ namespace Geo2Util {
     std::string toString(const Segment_2& seg) {
 
         return "LINE_SEGMENT " + toString(Geo2Util::DefaultBoundaryColor) + " "
-                + toString(Geo2Util::DefaultBoundaryType) + "\n"
-                + toString(seg.source()) + "\n"
-                + toString(seg.target());
+            + toString(Geo2Util::DefaultBoundaryType) + "\n"
+            + toString(seg.source()) + "\n"
+            + toString(seg.target());
     }
 
     /**
@@ -89,11 +89,11 @@ namespace Geo2Util {
     std::string toString(const Triangle_2& tri) {
 
         return "TRIANGLE " + toString(Geo2Util::DefaultBoundaryColor) + " "
-                + toString(Geo2Util::DefaultBoundaryType) + " "
-                + toString(Geo2Util::DefaultInteriorColor) + "\n"
-                + toString(tri[0]) + "\n"
-                + toString(tri[1]) + "\n"
-                + toString(tri[2]);
+            + toString(Geo2Util::DefaultBoundaryType) + " "
+            + toString(Geo2Util::DefaultInteriorColor) + "\n"
+            + toString(tri[0]) + "\n"
+            + toString(tri[1]) + "\n"
+            + toString(tri[2]);
     }
 
     /**
@@ -104,10 +104,48 @@ namespace Geo2Util {
     std::string toString(const Iso_rectangle_2& rect) {
 
         return "RECTANGLE " + toString(Geo2Util::DefaultBoundaryColor) + " "
-                + toString(Geo2Util::DefaultBoundaryType) + " "
-                + toString(Geo2Util::DefaultInteriorColor) + "\n"
-                + toString(rect.min()) + "\n"
-                + toString(rect.max());
+            + toString(Geo2Util::DefaultBoundaryType) + " "
+            + toString(Geo2Util::DefaultInteriorColor) + "\n"
+            + toString(rect.min()) + "\n"
+            + toString(rect.max());
+    }
+
+    /**
+     * @brief Convert Polygon_2 object to string with all its vertices
+     * @param poly Polygon_2 object
+     * @return A string object containing the representation of Polygon_2 object
+     */
+    std::string toString(const Polygon_2& poly) {
+        std::string points_str = "";
+        for (auto it = poly.begin(); it != poly.end(); ++it) {
+            points_str += toString(*it);
+            if (it != poly.end() - 1) points_str += "\n";
+        }
+
+        return "POLYGON " + std::to_string(poly.size()) + " "
+            + toString(Geo2Util::DefaultBoundaryColor) + " "
+            + toString(Geo2Util::DefaultBoundaryType) + " "
+            + toString(Geo2Util::DefaultInteriorColor) + "\n"
+            + points_str;
+    }
+
+    /**
+     * @brief Convert Polygon_2 object to string with all its holes and holes' vertices (the interiors of the holes are transparent and white by defalut)
+     * @param poly_w_h 
+     * @return 
+     */
+    std::string toString(const Polygon_with_holes_2& poly_w_h) {
+        std::string holes_str = "";
+        for (auto it = poly_w_h.holes_begin(); it != poly_w_h.holes_end(); ++it) {
+            holes_str += toString(*it, Geo2Util::DefaultBoundaryColor, Geo2Util::DefaultBoundaryType, TransparentWhite);
+            if (it != poly_w_h.holes_end() - 1) holes_str += "\n";
+        }
+
+        return "POLYGON_WITH_HOLES " + std::to_string(poly_w_h.number_of_holes()) + " "
+            + toString(Geo2Util::DefaultBoundaryColor) + " "
+            + toString(Geo2Util::DefaultBoundaryType) + " "
+            + toString(Geo2Util::DefaultInteriorColor) + "\n"
+            + holes_str;
     }
 
     // Customized toString
@@ -163,6 +201,34 @@ namespace Geo2Util {
             + toString(interiorColor) + "\n"
             + toString(rect.min(), boundaryColor, btype, boundaryColor) + "\n"
             + toString(rect.max(), boundaryColor, btype, boundaryColor);
+    }
+
+    std::string toString(const Polygon_2& poly, const Color& boundaryColor, const BoundaryType btype, const Color& interiorColor) {
+        std::string points_str = "";
+        for (auto it = poly.begin(); it != poly.end(); ++it) {
+            points_str += toString(*it, boundaryColor, btype, boundaryColor);
+            if (it != poly.end() - 1) points_str += "\n";
+        }
+
+        return "POLYGON " + std::to_string(poly.size()) + " "
+            + toString(boundaryColor) + " "
+            + toString(btype) + " "
+            + toString(interiorColor) + "\n"
+            + points_str;
+    }
+
+    std::string toString(const Polygon_with_holes_2& poly_w_h, const Color& boundaryColor, const BoundaryType btype, const Color& interiorColor) {
+        std::string holes_str = "";
+        for (auto it = poly_w_h.holes_begin(); it != poly_w_h.holes_end(); ++it) {
+            holes_str += toString(*it, boundaryColor, btype, TransparentWhite);
+            if (it != poly_w_h.holes_end() - 1) holes_str += "\n";
+        }
+
+        return "POLYGON_WITH_HOLES " + std::to_string(poly_w_h.number_of_holes()) + " "
+            + toString(boundaryColor) + " "
+            + toString(btype) + " "
+            + toString(interiorColor) + "\n"
+            + holes_str;
     }
 
     /**

--- a/Test/geo2_util.h
+++ b/Test/geo2_util.h
@@ -14,6 +14,8 @@ namespace Geo2Util {
     typedef K::Iso_rectangle_2 Iso_rectangle_2;
     typedef K::Triangle_2 Triangle_2;
     typedef K::Segment_2 Segment_2;
+    typedef K::Line_2 Line_2;
+    typedef K::Ray_2 Ray_2;
     typedef CGAL::Polygon_2<K> Polygon_2;
     typedef CGAL::Polygon_with_holes_2<K> Polygon_with_holes_2;
 
@@ -48,6 +50,8 @@ namespace Geo2Util {
     std::string toString(const Iso_rectangle_2& rect);
     std::string toString(const Polygon_2 & poly);
     std::string toString(const Polygon_with_holes_2 & poly_w_h);
+    std::string toString(const Line_2& line);
+    std::string toString(const Ray_2& ray);
 
     // Customized toString
     //! Underlying points of all objects (except Point_2) have the same color (boundary color and interior color) as its boundary color
@@ -59,6 +63,8 @@ namespace Geo2Util {
     std::string toString(const Iso_rectangle_2& rect, const Color& boundaryColor, const BoundaryType btype, const Color& interiorColor);
     std::string toString(const Polygon_2& poly, const Color& boundaryColor, const BoundaryType btype, const Color& interiorColor);
     std::string toString(const Polygon_with_holes_2& poly_w_h, const Color& boundaryColor, const BoundaryType btype, const Color& interiorColor);
+    std::string toString(const Line_2& line, const Color& boundaryColor, const BoundaryType btype);
+    std::string toString(const Ray_2& ray, const Color& boundaryColor, const BoundaryType btype);
     
     // Export 2D Geometry Object to File
     void printToFile(const std::string& filename, const std::vector<std::string>& geo2_Objects);

--- a/Test/geo2_util.h
+++ b/Test/geo2_util.h
@@ -43,7 +43,13 @@ namespace Geo2Util {
     std::string toString(const Iso_rectangle_2& rect);
 
     // Customized toString
-
+    //! Underlying points of all objects (except Point_2) have the same color (boundary color and interior color) as its boundary color
+    //! Underlying points of all objects have the same boundary type as the objects themselves
+    std::string toString(const Point_2& p, const Color& boundaryColor, const BoundaryType btype, const Color& interiorColor);
+    std::string toString(const Segment_2& seg, const Color& boundaryColor, const BoundaryType btype);
+    std::string toString(const Circle_2& circ, const Color& boundaryColor, const BoundaryType btype, const Color& interiorColor);
+    std::string toString(const Triangle_2& tri, const Color& boundaryColor, const BoundaryType btype, const Color& interiorColor);
+    std::string toString(const Iso_rectangle_2& rect, const Color& boundaryColor, const BoundaryType btype, const Color& interiorColor);
     
     // Export 2D Geometry Object to File
     void printToFile(const std::string& filename, const std::vector<std::string>& geo2_Objects);

--- a/Test/geo2_util.h
+++ b/Test/geo2_util.h
@@ -1,5 +1,7 @@
 #pragma once
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Polygon_2.h>
+#include <CGAL/Polygon_with_holes_2.h>
 
 #include <string>
 #include <vector>
@@ -12,6 +14,8 @@ namespace Geo2Util {
     typedef K::Iso_rectangle_2 Iso_rectangle_2;
     typedef K::Triangle_2 Triangle_2;
     typedef K::Segment_2 Segment_2;
+    typedef CGAL::Polygon_2<K> Polygon_2;
+    typedef CGAL::Polygon_with_holes_2<K> Polygon_with_holes_2;
 
     struct Color {
         short r;
@@ -29,6 +33,7 @@ namespace Geo2Util {
     // Constants
     const Color DefaultBoundaryColor = { 0, 0, 0, 255 };
     const Color DefaultInteriorColor = { 0, 0, 0, 255 };
+    const Color TransparentWhite = { 255, 255, 255, 0 };
     const BoundaryType DefaultBoundaryType = BoundaryType::Solid;
 
     // Visual Properties toString
@@ -41,6 +46,8 @@ namespace Geo2Util {
     std::string toString(const Circle_2& circ);
     std::string toString(const Triangle_2& tri);
     std::string toString(const Iso_rectangle_2& rect);
+    std::string toString(const Polygon_2 & poly);
+    std::string toString(const Polygon_with_holes_2 & poly_w_h);
 
     // Customized toString
     //! Underlying points of all objects (except Point_2) have the same color (boundary color and interior color) as its boundary color
@@ -50,6 +57,8 @@ namespace Geo2Util {
     std::string toString(const Circle_2& circ, const Color& boundaryColor, const BoundaryType btype, const Color& interiorColor);
     std::string toString(const Triangle_2& tri, const Color& boundaryColor, const BoundaryType btype, const Color& interiorColor);
     std::string toString(const Iso_rectangle_2& rect, const Color& boundaryColor, const BoundaryType btype, const Color& interiorColor);
+    std::string toString(const Polygon_2& poly, const Color& boundaryColor, const BoundaryType btype, const Color& interiorColor);
+    std::string toString(const Polygon_with_holes_2& poly_w_h, const Color& boundaryColor, const BoundaryType btype, const Color& interiorColor);
     
     // Export 2D Geometry Object to File
     void printToFile(const std::string& filename, const std::vector<std::string>& geo2_Objects);

--- a/Test/geo2_util.h
+++ b/Test/geo2_util.h
@@ -13,20 +13,38 @@ namespace Geo2Util {
     typedef K::Triangle_2 Triangle_2;
     typedef K::Segment_2 Segment_2;
 
-    std::string Black();
+    struct Color {
+        short r;
+        short g;
+        short b;
+        short trans = 255;
+    };
 
     enum class BoundaryType : short {
         Solid = 0,
         Dotted = 1,
         Dashed = 2
     };
-    std::string toString(const BoundaryType& t);
 
+    // Constants
+    const Color DefaultBoundaryColor = { 0, 0, 0, 255 };
+    const Color DefaultInteriorColor = { 0, 0, 0, 255 };
+    const BoundaryType DefaultBoundaryType = BoundaryType::Solid;
+
+    // Visual Properties toString
+    std::string toString(const Color& color);
+    std::string toString(const BoundaryType& bt);
+
+    // Default toString
     std::string toString(const Point_2& p);
     std::string toString(const Segment_2& seg);
     std::string toString(const Circle_2& circ);
     std::string toString(const Triangle_2& tri);
     std::string toString(const Iso_rectangle_2& rect);
 
+    // Customized toString
+
+    
+    // Export 2D Geometry Object to File
     void printToFile(const std::string& filename, const std::vector<std::string>& geo2_Objects);
 }

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -1,5 +1,7 @@
 
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Polygon_2.h>
+#include <CGAL/Polygon_with_holes_2.h>
 #include <string>
 #include <iostream>
 #include <fstream>
@@ -14,6 +16,9 @@ typedef K::Circle_2 Circle_2;
 typedef K::Iso_rectangle_2 Iso_rectangle_2;
 typedef K::Triangle_2 Triangle_2;
 typedef K::Segment_2 Segment_2;
+typedef CGAL::Polygon_2<K> Polygon_2;
+typedef CGAL::Polygon_with_holes_2<K> Polygon_with_holes_2;
+
 
 
 //std::string Black() {
@@ -86,53 +91,56 @@ typedef K::Segment_2 Segment_2;
 
 int main()
 {
-    //Point_2 p0(12, -15), p1(-10, -25.3), p2(-0.01, 0.2);
+    Point_2 p0(12, -15), p1(-10, -25.3), p2(-0.01, 0.2);
 
-    //Point_2 s1(10, 10), s2(40, 40);
-    //Segment_2 seg(s1, s2);
+    Point_2 s1(10, 10), s2(40, 40);
+    Segment_2 seg(s1, s2);
 
-    //Point_2 p(10, 10), q(20, 15), s(10, 15);
-    //Triangle_2 tri(p, q, s);
+    Point_2 p(10, 10), q(20, 15), s(10, 15);
 
-    //Circle_2 circ(p, 4);
+    Triangle_2 tri(p, q, s);
 
-    //Iso_rectangle_2 rect(p, q);
+    Circle_2 circ(p, 4);
+
+    Iso_rectangle_2 rect(p, q);
 
 
-    //std::vector<std::string> geomObjectArray;
-    //geomObjectArray.reserve(7); // only for observation purpose in this case; can be deleted
+    std::vector<std::string> geomObjectArray;
 
-    //geomObjectArray.push_back(Geo2Util::toString(p0));
-    //geomObjectArray.push_back(Geo2Util::toString(p1));
-    //geomObjectArray.push_back(Geo2Util::toString(p2));
-    //geomObjectArray.push_back(Geo2Util::toString(seg));
+    geomObjectArray.push_back(Geo2Util::toString(p0));
+    geomObjectArray.push_back(Geo2Util::toString(p1));
+    geomObjectArray.push_back(Geo2Util::toString(p2));
+    geomObjectArray.push_back(Geo2Util::toString(seg));
 
-    ////geomObjectArray[0] = Geo2Util::toString(p0);
-    ////geomObjectArray[1] = Geo2Util::toString(p1);
-    ////geomObjectArray[2] = Geo2Util::toString(p2);
-    ////geomObjectArray[3] = Geo2Util::toString(seg); 
-    ////geomObjectArray[4] = Geo2Util::toString(s1);
-    ////geomObjectArray[5] = Geo2Util::toString(s2);
+    geomObjectArray.push_back(Geo2Util::toString(circ));
 
-    //geomObjectArray.push_back(Geo2Util::toString(circ));
+    geomObjectArray.push_back(Geo2Util::toString(tri));
 
-    ////geomObjectArray[6] = Geo2Util::toString(circ);
-    ////geomObjectArray[7] = Geo2Util::toString(p);
-
-    //geomObjectArray.push_back(Geo2Util::toString(tri));
-
-    ////geomObjectArray[8] = Geo2Util::toString(tri);
-    ////geomObjectArray[9] = Geo2Util::toString(p);
-    ////geomObjectArray[10] = Geo2Util::toString(q);
-    ////geomObjectArray[11] = Geo2Util::toString(s);
-
-    //geomObjectArray.push_back(Geo2Util::toString(rect));
-
-    ////geomObjectArray[12] = Geo2Util::toString(rect);
-    ////geomObjectArray[13] = Geo2Util::toString(p);
-    ////geomObjectArray[14] = Geo2Util::toString(q);
+    geomObjectArray.push_back(Geo2Util::toString(rect));
   
-   
-    //Geo2Util::printToFile("test.txt", geomObjectArray);
+    // create a polygon with three holes
+    Polygon_2 poly;
+    poly.push_back(Point_2(0, 0)); poly.push_back(Point_2(9, 0));
+    poly.push_back(Point_2(6, 8)); poly.push_back(Point_2(5, 3));
+    poly.push_back(Point_2(2, 8)); poly.push_back(Point_2(0, 8));
+
+    geomObjectArray.push_back(Geo2Util::toString(poly));
+
+    std::vector<Polygon_2> holes(3);
+    holes[0].push_back(Point_2(6, 2)); holes[0].push_back(Point_2(7, 1));
+    holes[0].push_back(Point_2(7, 3)); holes[0].push_back(Point_2(6, 3));
+    holes[0].push_back(Point_2(5, 2));
+    holes[1].push_back(Point_2(2, 1)); holes[1].push_back(Point_2(3, 1));
+    holes[1].push_back(Point_2(3, 3)); holes[1].push_back(Point_2(2, 2));
+    holes[1].push_back(Point_2(1, 2));
+    holes[2].push_back(Point_2(1, 4)); holes[2].push_back(Point_2(2, 4));
+    holes[2].push_back(Point_2(2, 5)); holes[2].push_back(Point_2(3, 5));
+    holes[2].push_back(Point_2(3, 6)); holes[2].push_back(Point_2(1, 6));
+
+    Polygon_with_holes_2 poly_w_h(poly, holes.begin(), holes.end());
+
+    geomObjectArray.push_back(Geo2Util::toString(poly_w_h, Geo2Util::Color{ 2,3,3,4 }, Geo2Util::BoundaryType::Dotted, Geo2Util::Color{ 200,200,200,5 }));
+
+    Geo2Util::printToFile("test.txt", geomObjectArray);
 
 }

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -16,6 +16,8 @@ typedef K::Circle_2 Circle_2;
 typedef K::Iso_rectangle_2 Iso_rectangle_2;
 typedef K::Triangle_2 Triangle_2;
 typedef K::Segment_2 Segment_2;
+typedef K::Line_2 Line_2;
+typedef K::Ray_2 Ray_2;
 typedef CGAL::Polygon_2<K> Polygon_2;
 typedef CGAL::Polygon_with_holes_2<K> Polygon_with_holes_2;
 
@@ -139,7 +141,13 @@ int main()
 
     Polygon_with_holes_2 poly_w_h(poly, holes.begin(), holes.end());
 
-    geomObjectArray.push_back(Geo2Util::toString(poly_w_h, Geo2Util::Color{ 2,3,3,4 }, Geo2Util::BoundaryType::Dotted, Geo2Util::Color{ 200,200,200,5 }));
+    geomObjectArray.push_back(Geo2Util::toString(poly_w_h, Geo2Util::Color{ 159,246,37,100 }, Geo2Util::BoundaryType::Dotted, Geo2Util::Color{ 200,200,200,5 }));
+
+    Line_2 line(p, q);
+    geomObjectArray.push_back(Geo2Util::toString(line, Geo2Util::Color{ 200,200,200,60 }, Geo2Util::BoundaryType::Dashed));
+
+    Ray_2 ray(q, s);
+    geomObjectArray.push_back(Geo2Util::toString(ray, Geo2Util::Color{ 157,246,42,30 }, Geo2Util::BoundaryType::Dotted));
 
     Geo2Util::printToFile("test.txt", geomObjectArray);
 

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -135,7 +135,4 @@ int main()
    
     //Geo2Util::printToFile("test.txt", geomObjectArray);
 
-    Geo2Util::BoundaryType bt{ Geo2Util::BoundaryType::Solid };
-    cout << Geo2Util::toString(bt);
-
 }


### PR DESCRIPTION
* Added Color type
* Added two versions of toString for Point, Segment, Circle, Triangle, Iso_rectangle, Polygon, Polygon_with_hole, Ray and Line
        * By default, Point's interior color has the same color as boundary color -- single color solid point.
        * By default, the boundary color of the main object applies to all its underlying points (e.g. points on a polygon).
        * The boundary type of the main object applies to all its underlying points.
        * The interior color of holes (in Polygon_with_holes) is set to transparent and white ( Color {255, 255, 255, 0} );
* Minor bugfix  
* Minor adjustment of code format